### PR TITLE
Update to Kafka 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ A KafkaPrincipalBuilder that uses a regular expression to determine the authenti
 
 ## Supported Kafka versions:
 
-The `RegExPrincipalBuilder` has been tested with kafka `v2.0.0` and `v2.0.1`(see build.gradle for dependencies)
+|Kafka version|Connector version|
+|:-|:-|
+|2.1|1.0|
+|2.2|2.0|
 
 ## JMX Metrics
 RegexPrincipalBuilder emits two JMX metrics:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A KafkaPrincipalBuilder that uses a regular expression to determine the authenti
 
 ## Supported Kafka versions:
 
+The `RegexPrincipalBuilder` has been checked for compatibility with Kafka 2.0.0 - 2.2.0. See table below for the appropriate version to use:
+
 |Kafka version|Connector version|
 |:-|:-|
 |2.1|1.0|
@@ -24,7 +26,7 @@ kafka.security.RegexPrincipalBuilder
 
 ## Running the demo
 
-The demo runs a single-node zookeeper and kafka broker cluster with SASL_PLAINTEXT authentication.
+The demo runs a single-node zookeeper and Kafka broker cluster with SASL_PLAINTEXT authentication.
 
 In `docker-compose.yml`, the regular expression for resolving the principal name is `KAFKA_PRINCIPAL_BUILDER_REGEX: "(.+)\\..+"` which will resolve to just `my-principal` name for a naming convention of `<my-principal>.<my-user>`.
 
@@ -35,7 +37,7 @@ In `docker-compose.yml`, the regular expression for resolving the principal name
 $ gradle clean assemble
 ```
 
-### Start the kafka cluster.
+### Start the Kafka cluster.
 
 ```shell
 ~/regex-principal-builder$ cd demos/docker
@@ -52,7 +54,7 @@ The consumer acls are set to allow it to read from all topics (ALLOW_CONSUMER). 
 ~/regex-principal-builder/demos/docker$ ./test-acls
 ```
 
-### Tear-down kafka cluster
+### Tear-down Kafka cluster
 
 ```shell
 ~/regex-principal-builder/demos/docker$ docker-compose down

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply from:   'quality.gradle'
 apply plugin: 'checkstyle'
 
 group = 'com.nordstrom.kafka.security.auth'
-version = '1.0.0'
+version = '2.0.0'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
@@ -24,7 +24,7 @@ checkstyle {
 }
 
 dependencies {
-  implementation( 'org.apache.kafka:kafka_2.11:2.1.0' )
+  implementation( 'org.apache.kafka:kafka_2.12:2.2.0' )
   implementation( 'com.yammer.metrics:metrics-core:2.2.0' )
 
   testImplementation  'org.junit.jupiter:junit-jupiter-api:5.1.0'

--- a/demos/docker/docker-compose.yml
+++ b/demos/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     - ./private/jaas.zookeeper.conf:/var/private/jaas.conf
 
   bootstrap:
-    image: confluentinc/cp-kafka:5.1.0
+    image: confluentinc/cp-kafka:5.2.0
     entrypoint: /bootstrap.sh
     environment:
       KAFKA_OPTS: "-Djava.security.auth.login.config=/var/private/jaas.conf"
@@ -33,7 +33,7 @@ services:
     depends_on: [zookeeper]
 
   broker1:
-    image: confluentinc/cp-kafka:5.1.0
+    image: confluentinc/cp-kafka:5.2.0
     networks:
       - kafka_local
     ports:
@@ -77,7 +77,7 @@ services:
 
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
 
-      # Include principal-builder jar file to class path.
+      # Include principal-builder jar file in classpath.
       CLASSPATH: "/var/lib/extras/*"
       KAFKA_PRINCIPAL_BUILDER_CLASS: "com.nordstrom.kafka.security.auth.RegexPrincipalBuilder"
       # Regex to derive principal following 'principal.uid' naming convention
@@ -137,7 +137,7 @@ services:
   #
   #     KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
   #
-  #     # Include principal-builder jar file to class path.
+  #     # Include principal-builder jar file in classpath.
   #     CLASSPATH: "/var/lib/extras/*"
   #     KAFKA_PRINCIPAL_BUILDER_CLASS: "com.nordstrom.kafka.security.auth.RegexPrincipalBuilder"
   #     # Regex to derive principal following 'slash-path' naming convention of <principal>/<user>

--- a/src/main/java/com/nordstrom/kafka/security/auth/RegexPrincipalBuilder.java
+++ b/src/main/java/com/nordstrom/kafka/security/auth/RegexPrincipalBuilder.java
@@ -45,7 +45,7 @@ public class RegexPrincipalBuilder implements KafkaPrincipalBuilder {
   public RegexPrincipalBuilder() {
     super();
 
-    kafkaPrincipalBuilder = new DefaultKafkaPrincipalBuilder(null);
+    kafkaPrincipalBuilder = new DefaultKafkaPrincipalBuilder(null, null);
     // NB: RegexPrincipal builder will throw an exception for a malformed regex.
     regexPrincipal = new RegexPrincipal(KAFKA_PRINCIPAL_BUILDER_REGEX_ENV_VAR);
   }


### PR DESCRIPTION
Updated dependency to `kafka_2.12`, `2.2.0`.  Note change of scala version from `kafka-2.11` based on recommendation here: https://kafka.apache.org/downloads