### PR TITLE
Add value to metrics fields

### DIFF
--- a/src/main/java/com/nordstrom/kafka/security/auth/RegexPrincipalBuilder.java
+++ b/src/main/java/com/nordstrom/kafka/security/auth/RegexPrincipalBuilder.java
@@ -31,9 +31,9 @@ public class RegexPrincipalBuilder implements KafkaPrincipalBuilder {
   // 'type', 'name', and 'scope'.
   // See
   // http://javadox.com/com.yammer.metrics/metrics-core/2.2.0/com/yammer/metrics/core/MetricName.html#MetricName(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String)
-  private final MetricName requestsName = new MetricName("proton", "RegexPrincipalBuilder", "RequestsPerSec", "kafka.security",
+  private final MetricName requestsName = new MetricName("kafka", "RegexPrincipalBuilder", "RequestsPerSec", "kafka.security",
       "kafka.security:type=RegexPrincipalBuilder,name=RequestsPerSec");
-  private final MetricName errorsName = new MetricName("proton", "RegexPrincipalBuilder", "ErrorsPerSec", "kafka.security",
+  private final MetricName errorsName = new MetricName("kafka", "RegexPrincipalBuilder", "ErrorsPerSec", "kafka.security",
       "kafka.security:type=RegexPrincipalBuilder,name=ErrorsPerSec");
   private final Meter requests =
       Metrics.newMeter(requestsName, "regex-principal-builder", TimeUnit.SECONDS);

--- a/src/main/java/com/nordstrom/kafka/security/auth/RegexPrincipalBuilder.java
+++ b/src/main/java/com/nordstrom/kafka/security/auth/RegexPrincipalBuilder.java
@@ -31,9 +31,9 @@ public class RegexPrincipalBuilder implements KafkaPrincipalBuilder {
   // 'type', 'name', and 'scope'.
   // See
   // http://javadox.com/com.yammer.metrics/metrics-core/2.2.0/com/yammer/metrics/core/MetricName.html#MetricName(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String)
-  private final MetricName requestsName = new MetricName("", "", "", "",
+  private final MetricName requestsName = new MetricName("proton", "RegexPrincipalBuilder", "RequestsPerSec", "kafka.security",
       "kafka.security:type=RegexPrincipalBuilder,name=RequestsPerSec");
-  private final MetricName errorsName = new MetricName("", "", "", "",
+  private final MetricName errorsName = new MetricName("proton", "RegexPrincipalBuilder", "ErrorsPerSec", "kafka.security",
       "kafka.security:type=RegexPrincipalBuilder,name=ErrorsPerSec");
   private final Meter requests =
       Metrics.newMeter(requestsName, "regex-principal-builder", TimeUnit.SECONDS);


### PR DESCRIPTION
https://github.com/Nordstrom/kafka-regex-principal-builder/issues/4: add values to metrics field -group, type, name and scope so that cruise-control doesn't throw exception for that